### PR TITLE
PackmolBoxGen incorrectly adding " to input script

### DIFF
--- a/pymatgen/io/packmol.py
+++ b/pymatgen/io/packmol.py
@@ -163,7 +163,7 @@ class PackmolBoxGen(InputGenerator):
         file_contents += "filetype xyz\n\n"
         # NOTE - output filename MUST be enclosed in double quotes in order to work
         # when there are spaces in the filename. Single quotes will not work.
-        file_contents += f'output "{self.outputfile}"\n\n'
+        file_contents += f'output {self.outputfile}\n\n'
 
         if box:
             box_list = " ".join(str(i) for i in box)
@@ -195,7 +195,7 @@ class PackmolBoxGen(InputGenerator):
                 mol = d["coords"]
             fname = f"packmol_{d['name']}.xyz"
             mapping.update({fname: mol.to(fmt="xyz")})
-            file_contents += f'structure "{fname}"\n'
+            file_contents += f'structure {fname}\n'
             file_contents += "  number {}\n".format(str(d["number"]))
             file_contents += "  inside box {}\n".format(box_list)
             file_contents += "end structure\n\n"

--- a/pymatgen/io/packmol.py
+++ b/pymatgen/io/packmol.py
@@ -59,6 +59,7 @@ class PackmolSet(InputSet):
                 "Don't forget to add the packmol binary to your path"
             )
         try:
+            wd = os.getcwd()
             os.chdir(path)
             p = subprocess.run(
                 "packmol < '{}'".format(self.inputfile),
@@ -68,6 +69,7 @@ class PackmolSet(InputSet):
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
             )
+            os.chdir(wd)
             # this workaround is needed because packmol can fail to find
             # a solution but still return a zero exit code
             # see https://github.com/m3g/packmol/issues/28
@@ -211,3 +213,4 @@ class PackmolBoxGen(InputGenerator):
             control_params=self.control_params,
             tolerance=self.tolerance,
         )
+


### PR DESCRIPTION
Fixed an issue where quotation marks inside strings were causing packmol to not recognize file names.